### PR TITLE
Version 5.3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cachetools" %}
-{% set version = "4.2.2" %}
+{% set version = "5.3.3" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
+  sha256: ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.5
-    - setuptools >=46.4.0
+    - python
+    - setuptools
     - wheel
   run:
-    - python >=3.5
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
 
   description: |
     This module provides various memoizing collections and decorators, including variants of the Python 3 Standard Library @lru_cache function decorator.
-  doc_url: http://pythonhosted.org/cachetools/
+  doc_url: https://pypi.org/project/cachetools/
   dev_url: https://github.com/tkem/cachetools
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
cachetools 5.3.3

**Destination channel:** defaults

### Links

- [PKG-4498](https://anaconda.atlassian.net/browse/PKG-4498)
- [Upstream repository](https://github.com/tkem/cachetools/tree/v5.3.3)
- [Upstream changelog/diff](https://github.com/tkem/cachetools/blob/v5.3.3/CHANGELOG.rst)

### Explanation of changes:

- Update version
- Dependency updates
- Remove noarch and add python version skip
- Linter fixes

[PKG-4498]: https://anaconda.atlassian.net/browse/PKG-4498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ