### PR TITLE
cachetools 6.2.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "cachetools" %}
-{% set version = "5.5.1" %}
-
+{% set version = "6.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 70f238fbba50383ef62e55c6aff6d9673175fe59f7c6782c7a0b9e38f4a9df95
+  sha256: 8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
cachetools 6.2.2 

**Destination channel:** Defaults

### Links

- [PKG-11007]
- dev_url:        https://github.com/tkem/cachetools/tree/v6.2.2
- conda_forge:    https://github.com/conda-forge/cachetools-feedstock
- pypi:           https://pypi.org/project/cachetools/6.2.2
- pypi inspector: https://inspector.pypi.io/project/cachetools/6.2.2

### Explanation of changes:

- new version number


[PKG-11007]: https://anaconda.atlassian.net/browse/PKG-11007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ